### PR TITLE
perf: Use unchecked for nonce++ in ERC20Permit

### DIFF
--- a/contracts/token/erc20/Erc20Permit.sol
+++ b/contracts/token/erc20/Erc20Permit.sol
@@ -86,8 +86,10 @@ contract Erc20Permit is
             revert Erc20Permit__PermitExpired(deadline);
         }
 
-        // It's safe to use the "+" operator here because the nonce cannot realistically overflow, ever.
-        bytes32 hashStruct = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, amount, nonces[owner]++, deadline));
+        // It's safe to use unchecked here because the nonce cannot realistically overflow, ever.
+        unchecked {
+            bytes32 hashStruct = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, amount, nonces[owner]++, deadline));
+        }
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, hashStruct));
         address recoveredOwner = ecrecover(digest, v, r, s);
 


### PR DESCRIPTION
When this repo used 0.7 just using ++ made things unchecked. However during the upgrade to 0.8 this must have been missed and the comment indicates the operation is unchecked, but it is not. Wrapping it with unchecked restores the old optimization. 