### PR TITLE
fix: adopt permit typehash that is more commonly used

### DIFF
--- a/contracts/token/erc20/Erc20Permit.sol
+++ b/contracts/token/erc20/Erc20Permit.sol
@@ -33,7 +33,7 @@ contract Erc20Permit is
 
     /// @inheritdoc IErc20Permit
     bytes32 public constant override PERMIT_TYPEHASH =
-        0xfc77c2b9d30fe91687fd39abb7d16fcdfe1472d065740051ab8b13e4bf4a617f;
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
 
     /// @inheritdoc IErc20Permit
     mapping(address => uint256) public override nonces;
@@ -70,7 +70,7 @@ contract Erc20Permit is
     function permit(
         address owner,
         address spender,
-        uint256 amount,
+        uint256 value,
         uint256 deadline,
         uint8 v,
         bytes32 r,
@@ -89,7 +89,7 @@ contract Erc20Permit is
         // It's safe to use unchecked here because the nonce cannot realistically overflow, ever.
         bytes32 hashStruct;
         unchecked {
-            hashStruct = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, amount, nonces[owner]++, deadline));
+            hashStruct = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonces[owner]++, deadline));
         }
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, hashStruct));
         address recoveredOwner = ecrecover(digest, v, r, s);
@@ -101,6 +101,6 @@ contract Erc20Permit is
             revert Erc20Permit__InvalidSignature(v, r, s);
         }
 
-        approveInternal(owner, spender, amount);
+        approveInternal(owner, spender, value);
     }
 }

--- a/contracts/token/erc20/IErc20Permit.sol
+++ b/contracts/token/erc20/IErc20Permit.sol
@@ -13,7 +13,7 @@ import "./IErc20.sol";
 interface IErc20Permit is IErc20 {
     /// NON-CONSTANT FUNCTIONS ///
 
-    /// @notice Sets `amount` as the allowance of `spender` over `owner`'s tokens, assuming the latter's
+    /// @notice Sets `value` as the allowance of `spender` over `owner`'s tokens, assuming the latter's
     /// signed approval.
     ///
     /// @dev Emits an {Approval} event.
@@ -32,7 +32,7 @@ interface IErc20Permit is IErc20 {
     function permit(
         address owner,
         address spender,
-        uint256 amount,
+        uint256 value,
         uint256 deadline,
         uint8 v,
         bytes32 r,
@@ -47,7 +47,7 @@ interface IErc20Permit is IErc20 {
     /// @notice Provides replay protection.
     function nonces(address account) external view returns (uint256);
 
-    /// @notice keccak256("Permit(address owner,address spender,uint256 amount,uint256 nonce,uint256 deadline)");
+    /// @notice keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
     function PERMIT_TYPEHASH() external view returns (bytes32);
 
     /// @notice Eip712 version of this implementation.

--- a/test/shared/eip2612.ts
+++ b/test/shared/eip2612.ts
@@ -8,7 +8,7 @@ import { Erc20Permit } from "../../src/types/Erc20Permit";
 
 // Must match the typehash in Erc20PermitStorage.sol
 export const PERMIT_TYPEHASH: string = keccak256(
-  toUtf8Bytes("Permit(address owner,address spender,uint256 amount,uint256 nonce,uint256 deadline)"),
+  toUtf8Bytes("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"),
 );
 
 // Must match the version in Erc20PermitStorage.sol


### PR DESCRIPTION
Changing the `PERMIT_TYPEHASH` in `Erc20Permit.sol` to a more commonly adopted hash:

```solidity
keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
```